### PR TITLE
Add GenreController with CRUD endpoints

### DIFF
--- a/src/main/java/com/audiotracker/audiotracker_api/controller/GenreController.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/controller/GenreController.java
@@ -1,0 +1,41 @@
+package com.audiotracker.audiotracker_api.controller;
+
+import com.audiotracker.audiotracker_api.model.Genre;
+import com.audiotracker.audiotracker_api.service.GenreService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/genres/")
+public class GenreController {
+
+    @Autowired
+    private GenreService genreService;
+
+    @GetMapping
+    public List<Genre> getAllGenres() {
+        return genreService.getAllGenres();
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Genre> getGenreById(@PathVariable long id) {
+        return genreService.getGenreById(id)
+                .map(ResponseEntity::ok)
+                .orElse(ResponseEntity.notFound().build());
+    }
+
+    @PostMapping
+    public ResponseEntity<Genre> updateGenre(@PathVariable Long id, @RequestBody Genre genre) {
+        Genre updated = genreService.updateGenre(id, genre);
+        return (updated != null) ? ResponseEntity.ok(updated) : ResponseEntity.notFound().build();
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteGenre(@PathVariable Long id) {
+        genreService.deleteGenre(id);
+        return ResponseEntity.noContent().build();
+    }
+}


### PR DESCRIPTION
Added GenreController with REST endpoints to create, read, update, and delete Genre entities using GenreService.