### PR TITLE
Added custom endpoint to retrieve audiobooks by user ID using derived query in AudiobookRepo

### DIFF
--- a/src/main/java/com/audiotracker/audiotracker_api/controller/AudiobookController.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/controller/AudiobookController.java
@@ -27,6 +27,12 @@ public class AudiobookController {
                 .orElse(ResponseEntity.notFound().build());
     }
 
+  @GetMapping("/user/{userId}")
+        public ResponseEntity<List<Audiobook>> getAudiobooksByUser(@PathVariable Long userId) {
+            List<Audiobook> books = audiobookService.getAudiobooksByUser(userId);
+            return ResponseEntity.ok(books);
+        }
+
     @PostMapping
     public Audiobook createAudiobook(@RequestBody Audiobook audiobook) {
         return audiobookService.createAudiobook(audiobook);

--- a/src/main/java/com/audiotracker/audiotracker_api/repository/AudiobookRepo.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/repository/AudiobookRepo.java
@@ -3,5 +3,8 @@ package com.audiotracker.audiotracker_api.repository;
 import com.audiotracker.audiotracker_api.model.Audiobook;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface AudiobookRepo extends JpaRepository<Audiobook, Long> {
+    List<Audiobook> findBySessionsUserId(Long userId);
 }

--- a/src/main/java/com/audiotracker/audiotracker_api/service/AudiobookService.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/service/AudiobookService.java
@@ -21,6 +21,10 @@ public class AudiobookService {
         return audiobookRepo.findById(id);
     }
 
+    public List<Audiobook> getAudiobooksByUser(Long userId) {
+        return audiobookRepo.findBySessionsUserId(userId);
+    }
+
     public Audiobook createAudiobook(Audiobook audiobook) {
         return audiobookRepo.save(audiobook);
     }


### PR DESCRIPTION
Added new custom endpoint in AudiobookController to retrieve a list of audiobooks based on a user’s ID. Includes derived query method in AudiobookRepo and corresponding service logic in AudiobookService. Enables GET /api/audiobooks/user/{userId} for client-side retrieval.