### PR TITLE
Added REST endpoint to fetch recent sessions with optional count parameter

### DIFF
--- a/src/main/java/com/audiotracker/audiotracker_api/controller/SessionController.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/controller/SessionController.java
@@ -57,4 +57,10 @@ public class SessionController {
         return audiobooks.isEmpty() ? ResponseEntity.notFound().build() : ResponseEntity.ok(audiobooks);
     }
 
+    @GetMapping("/recent")
+    public ResponseEntity<List<Session>> getRecentSessions(@RequestParam(defaultValue = "5") int count) {
+        List<Session> sessions = sessionService.getRecentSessions(count);
+        return ResponseEntity.ok(sessions);
+    }
+
 }

--- a/src/main/java/com/audiotracker/audiotracker_api/model/Session.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/model/Session.java
@@ -1,5 +1,6 @@
 package com.audiotracker.audiotracker_api.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import com.audiotracker.audiotracker_api.model.User;
 
@@ -17,10 +18,12 @@ public class Session {
 
     @ManyToOne
     @JoinColumn(name = "user_id")
+    @JsonIgnore
     private User user;
 
     @ManyToOne
     @JoinColumn(name = "audiobook_id")
+    @JsonIgnore
     private Audiobook audiobook;
 
     // GETTERS & SETTERS

--- a/src/main/java/com/audiotracker/audiotracker_api/repository/SessionRepo.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/repository/SessionRepo.java
@@ -13,6 +13,8 @@ public interface SessionRepo extends JpaRepository<Session, Long> {
     Integer totalListeningByUser(@Param("userId") Long userId);
     @Query("SELECT DISTINCT s.audiobook FROM Session s where s.user.id = :userId")
     List<Audiobook> findAudiobooksByUserId(@Param("userId") Long userId);
+    @Query("SELECT s FROM Session s ORDER BY s.date DESC")
+    List<Session> findRecentSessions(org.springframework.data.domain.Pageable pageable);
 }
 
 

--- a/src/main/java/com/audiotracker/audiotracker_api/service/AudiobookService.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/service/AudiobookService.java
@@ -21,14 +21,6 @@ public class AudiobookService {
         return audiobookRepo.findById(id);
     }
 
-    public List<Audiobook> getAudiobooksByUser(Long userId) {
-        return audiobookRepo.findBySessionsUserId(userId);
-    }
-
-    public List<Audiobook> getAudiobooksByGenre(Long genreId) {
-        return audiobookRepo.findByGenreId(genreId);
-    }
-
     public Audiobook createAudiobook(Audiobook audiobook) {
         return audiobookRepo.save(audiobook);
     }
@@ -45,5 +37,13 @@ public class AudiobookService {
     }
     public void deleteAudiobook(long id) {
         audiobookRepo.deleteById(id);
+    }
+
+    public List<Audiobook> getAudiobooksByUser(Long userId) {
+        return audiobookRepo.findBySessionsUserId(userId);
+    }
+
+    public List<Audiobook> getAudiobooksByGenre(Long genreId) {
+        return audiobookRepo.findByGenreId(genreId);
     }
 }

--- a/src/main/java/com/audiotracker/audiotracker_api/service/GenreService.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/service/GenreService.java
@@ -17,9 +17,6 @@ public class GenreService {
     public List<Genre> getAllGenres() {
         return genreRepo.findAll();
     }
-    public Optional<Genre> getGenreById(long id) {
-        return genreRepo.findById(id);
-    }
     public Genre createGenre(Genre genre) {
         return genreRepo.save(genre);
     }
@@ -32,5 +29,9 @@ public class GenreService {
     }
     public void deleteGenre(long id) {
         genreRepo.deleteById(id);
+    }
+
+    public Optional<Genre> getGenreById(long id) {
+        return genreRepo.findById(id);
     }
 }

--- a/src/main/java/com/audiotracker/audiotracker_api/service/SessionService.java
+++ b/src/main/java/com/audiotracker/audiotracker_api/service/SessionService.java
@@ -4,6 +4,7 @@ import com.audiotracker.audiotracker_api.model.Audiobook;
 import com.audiotracker.audiotracker_api.model.Session;
 import com.audiotracker.audiotracker_api.repository.SessionRepo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -41,8 +42,11 @@ public class SessionService {
         return sessionRepo.findAudiobooksByUserId(userId);
     }
 
-
     public Integer getTotalListeningByUser(Long userId) {
         return sessionRepo.totalListeningByUser(userId);
+    }
+
+    public List<Session> getRecentSessions(int count) {
+        return sessionRepo.findRecentSessions(PageRequest.of(0, count));
     }
 }


### PR DESCRIPTION
Added a custom endpoint to retrieve the most recent audiobook listening sessions. This update includes a new query method in `SessionRepo`, logic in `SessionService`, and a mapped route in `SessionController` that accepts an optional `count` parameter (default is 5). The endpoint returns the latest sessions ordered by date descending.
